### PR TITLE
remove calls to "sudo apt-get ..." on */install.py

### DIFF
--- a/ipol/wrappers/Non_Local_Means_Denoising/install.py
+++ b/ipol/wrappers/Non_Local_Means_Denoising/install.py
@@ -21,7 +21,6 @@ def _install():
    # getting example images
    urllib.urlretrieve('http://www.ipol.im/pub/art/2011/bcm_nlm/cinput.jpg',os.path.join(exec_folder,'cinput.jpg'))
    urllib.urlretrieve('http://www.ipol.im/pub/art/2011/bcm_nlm/cnoisy.jpg',os.path.join(exec_folder,'cnoisy.jpg'))
-   os.system( 'sudo apt-get install build-essential libjpeg8-dev libpng-dev libtiff-dev')
    this_file_path=os.path.dirname(__file__)
    subprocess.call('make', shell=True,cwd=exec_folder)   
    

--- a/ipol/wrappers/Rudin_Osher_Fatemi_Total_Variation_Denoising_using_Split_Bregman/install.py
+++ b/ipol/wrappers/Rudin_Osher_Fatemi_Total_Variation_Denoising_using_Split_Bregman/install.py
@@ -13,7 +13,6 @@ def _install():
    """this function downloads and compile the code for the chanvese implementation"""
    download_file='http://www.ipol.im/pub/art/2012/g-tvd/tvdenoise_20120516.tar.gz'
    tools.download_and_extract(download_file)  
-   os.system( 'sudo apt-get install build-essential libjpeg8-dev libpng-dev libtiff-dev')
    this_file_path=os.path.dirname(__file__)
    subprocess.call('make -f makefile.gcc', shell=True,cwd=exec_folder)   
    

--- a/ipol/wrappers/TV_L1_Optical_Flow_Estimation/install.py
+++ b/ipol/wrappers/TV_L1_Optical_Flow_Estimation/install.py
@@ -18,7 +18,6 @@ def _install():
    """this function downloads and compile the code """
    download_file='http://www.ipol.im/pub/art/2013/26/tvl1flow_3.tar.gz'
    tools.download_and_extract(download_file)  
-   os.system( 'sudo apt-get install build-essential libjpeg8-dev libpng-dev libtiff-dev')
    this_file_path=os.path.dirname(__file__)
    subprocess.call('make', shell=True,cwd=exec_folder)   
    

--- a/ipol/wrappers/Variational_Framework_for_Non_Local_Inpainting/install.py
+++ b/ipol/wrappers/Variational_Framework_for_Non_Local_Inpainting/install.py
@@ -19,7 +19,6 @@ def _install():
    """this function downloads and compile the code for the inpainting implementation"""
    download_file='http://www.ipol.im/pub/art/2015/136/inpaint_8.tgz'
    tools.download_and_extract(download_file)  
-   os.system( 'sudo apt-get install build-essential libjpeg8-dev libpng-dev libtiff-dev')
    this_file_path=os.path.dirname(__file__)
    subprocess.call(' mkdir build; cd build; cmake ..; make', shell=True,cwd=exec_folder)   
   

--- a/ipol/wrappers/chanvese_segmentation/install.py
+++ b/ipol/wrappers/chanvese_segmentation/install.py
@@ -18,7 +18,6 @@ def _install():
    """this function downloads and compile the code for the chanvese implementation"""
    download_file='http://www.ipol.im/pub/art/2012/g-cv/chanvese_20120715.tar.gz'
    tools.download_and_extract(download_file)  
-   os.system( 'sudo apt-get install build-essential libjpeg8-dev libpng-dev libtiff-dev')
    this_file_path=os.path.dirname(__file__)
    subprocess.call('make -f makefile.gcc', shell=True,cwd=exec_folder)   
    


### PR DESCRIPTION
Rationale: by requirement, all ipol codes depend on the same libraries.  Thus, these requirements should be global, not local to each algorithm.
